### PR TITLE
🎨 상점 디자인 보완

### DIFF
--- a/dv/lib/shop/shop_items.dart
+++ b/dv/lib/shop/shop_items.dart
@@ -1,13 +1,13 @@
 //  포인트 상점에서 판매할 상품 리스트
 class ShopItemList {
   static Map<String, List<dynamic>> items = {
-    "dog": ["dog", 200, false], // 이미지 파일명, 가격, 구매 여부
-    "dog2": ["dog2", 500, false],
-    "snake": ["snake", 300, false],
-    "snake2": ["snake2", 600, false],
-    "owl": ["owl", 300, false],
-    "owl2": ["owl2", 600, false],
-    "deer": ["deer", 300, false],
-    "deer2": ["deer2", 600, false]
+    "dog": ["Dog", 200, false], // 이미지 파일명, 가격, 구매 여부
+    "dog2": ["Dog_Black.ver", 500, false],
+    "snake": ["Snake", 300, false],
+    "snake2": ["Snake_Black.ver", 600, false],
+    "owl": ["Owl", 300, false],
+    "owl2": ["Owl_Black.ver", 600, false],
+    "deer": ["Deer", 300, false],
+    "deer2": ["Deer_Black.ver", 600, false]
   };
 }

--- a/dv/lib/shop/shop_screen.dart
+++ b/dv/lib/shop/shop_screen.dart
@@ -27,14 +27,37 @@ class ShopScreen extends StatelessWidget {
       floatingActionButton: FloatingMenuButton(), //  메뉴 버튼
       body: Column(
         children: [
+        
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: loginProvider.isLoggedIn
                 ?
                 //  로그인 상태일 때 보유 포인트 표시
-                Text(
-                    "보유 포인트: ${shopProvider.userPoints}",
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                Container(
+                    width: double.infinity,
+                    height: 100,
+                    alignment: Alignment.center,
+                    margin: EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10.0),
+                        color: ColorPalette
+                              .palette[themeProvider.selectedThemeIndex][3]),
+                    child: Row(
+  mainAxisSize: MainAxisSize.min, // 최소 크기로 조정
+  children: [
+    Icon(Icons.confirmation_num_outlined, size: 24, color: ColorPalette.palette[themeProvider.selectedThemeIndex][0]), // 코인 아이콘
+    SizedBox(width: 8), // 아이콘과 텍스트 간격
+    Text(
+      "보유 포인트: ${shopProvider.userPoints}",
+      style: TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.bold,
+        color: ColorPalette.palette[themeProvider.selectedThemeIndex][0],
+      ),
+    ),
+  ],
+),
+
                   )
                 : SizedBox(), // 로그아웃 상태일 때 아무것도 표시하지 않음
           ),
@@ -48,64 +71,100 @@ class ShopScreen extends StatelessWidget {
                     shopProvider.items[itemName]!; // 상품 데이터 리스트(가격, 구매 여부)
                 final isPurchased = itemData[2] as bool; // 구매 여부
 
-                return Padding(
-                  padding:
-                      const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      // 이미지 (leading)
-                      SizedBox(
-                        width: 200,
-                        height: 200,
-                        child: Image.asset(
-                          "profile/$itemName.png", //  이미지 주소
-                          fit: BoxFit.fill, // 이미지 영역 꽉 채우기
-                        ),
-                      ),
-                      const SizedBox(width: 16), // 이미지와 텍스트 간격
-                      // 텍스트 (title, subtitle)
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              "${itemData[1]} pt", //  가격 표시
-                              style: TextStyle(
-                                  fontSize: 20, fontWeight: FontWeight.bold),
+                return SizedBox(
+                  width: double.infinity,
+                  child: Container(
+                    decoration: BoxDecoration(
+                    color: ColorPalette.palette[themeProvider.selectedThemeIndex][1], // 아이템 전체 배경색
+                    border: Border.all(
+                    color: ColorPalette.palette[themeProvider.selectedThemeIndex][0], // 테두리 색상
+                     width: 2, // 테두리 두께
+                  ),
+               borderRadius: BorderRadius.circular(12), // 모서리 둥글게
+                ),
+                //padding: EdgeInsets.all(12), // 내부 패딩 추가
+               margin: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        // 이미지 (leading)
+                              Expanded(
+                        child: ShaderMask(
+                          shaderCallback: (Rect bounds) {
+                            return LinearGradient(
+                              begin: Alignment(0.2, 0.0),
+                              end: Alignment(0.9,0.0),
+                              colors: [Colors.white, Colors.transparent],
+                            ).createShader(bounds);
+                          },
+                          blendMode: BlendMode.dstIn,
+                          child: Container(
+                            width: 200,
+                            height: 200,
+                            decoration: BoxDecoration(
+                              image: DecorationImage(
+                                image: AssetImage("profile/$itemName.png"),
+                                fit: BoxFit.cover,
+                              ),
                             ),
-                          ],
+                          ),// 이미지를 꽉 차게 조정
+                               ),
+                             ),
+                        const SizedBox(width: 50), // 이미지와 텍스트 간격
+                        // 텍스트 (title, subtitle)
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Container(
+                                width: double.infinity,
+                               height: 50,
+                               alignment: Alignment.centerRight,
+                               margin: EdgeInsets.all(10),
+                               decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10.0),
+                              color: ColorPalette
+                                .palette[themeProvider.selectedThemeIndex][1]),
+                              child: Text(
+                                "${itemData[1]} pt", //  가격 표시
+                                style: TextStyle(
+                                    fontSize: 40, fontWeight: FontWeight.bold),
+                              ),
+                              ),
+                              
+                            ],
+                          ),
                         ),
-                      ),
-                      loginProvider.isLoggedIn // 로그인 상태일 때 구매 아이콘 및 품절 여부 표시
-                          ? isPurchased
-                              // 구매 된 경우 품절 표시
-                              ? Text(
-                                  languageProvider.getLanguage(message: "품절"),
-                                  style: TextStyle(
-                                      color: Colors.red,
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.bold),
-                                )
-                              //  구매 안 된 경우 구매 아이콘 표시
-                              : GestureDetector(
-                                  onTap: () {
-                                    _showPurchaseDialog(
-                                        context,
-                                        itemName,
-                                        itemData[0],
-                                        itemData[1],
-                                        languageProvider,
-                                        themeProvider);
-                                  },
-                                  child: Icon(Icons.shopping_cart,
-                                      color: ColorPalette.palette[
-                                          themeProvider.selectedThemeIndex][3],
-                                      size: 24),
-                                )
-                          //  로그아웃 상태인 경우 아이콘 및 품절 표시 하지 않음
-                          : SizedBox(),
-                    ],
+                        loginProvider.isLoggedIn // 로그인 상태일 때 구매 아이콘 및 품절 여부 표시
+                            ? isPurchased
+                                // 구매 된 경우 품절 표시
+                                ? Text(
+                                    languageProvider.getLanguage(message: "품절"),
+                                    style: TextStyle(
+                                        color: Colors.grey,
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.bold),
+                                  )
+                                //  구매 안 된 경우 구매 아이콘 표시
+                                : GestureDetector(
+                                    onTap: () {
+                                      _showPurchaseDialog(
+                                          context,
+                                          itemName,
+                                          itemData[0],
+                                          itemData[1],
+                                          languageProvider,
+                                          themeProvider);
+                                    },
+                                    child: Icon(Icons.shopping_cart,
+                                        color: ColorPalette.palette[
+                                            themeProvider.selectedThemeIndex][3],
+                                        size: 30),
+                                  )
+                            //  로그아웃 상태인 경우 아이콘 및 품절 표시 하지 않음
+                            : SizedBox(),
+                      ],
+                    ),
                   ),
                 );
               },
@@ -135,13 +194,16 @@ class ShopScreen extends StatelessWidget {
               content: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Image.asset(
-                    "profile/$imagePath.png", //  이미지 경로
-                    width: 200,
-                    height: 200,
-                  ),
-                  SizedBox(height: 10),
-                  Text("가격: $price 포인트"), //  가격 표시
+                  SizedBox(
+                      width: 200,
+                      height: 200,
+                      child: ClipOval( // 이미지를 동그랗게 자름
+                      child: Image.asset(
+                      "profile/$itemName.png", // 이미지 주소
+                      fit: BoxFit.cover, // 이미지를 꽉 차게 조정
+                      ),
+                     ),
+                   ), //  가격 표시
                 ],
               ),
               actions: [
@@ -164,7 +226,7 @@ class ShopScreen extends StatelessWidget {
                 ),
                 //  구매 버튼
                 ElevatedButton.icon(
-                  icon: Icon(Icons.shopping_bag),
+                  icon: Icon(Icons.shopping_bag_outlined),
                   style: ElevatedButton.styleFrom(
                       backgroundColor: ColorPalette
                           .palette[themeProvider.selectedThemeIndex][2],


### PR DESCRIPTION
<포인트 이미지>
-눈에 더 잘 보이도록 container 포함
-아이콘 추가

<프로필 아이템 리스트>
-캐릭터가 더 잘 보이도록 container 포함
-shade로 자연스럽게 뭉겜
-구매 화면에선 프로필 미리보기 느낌으로 동그랗게 잘라서 보여줌
-품절 시 텍스트 색 변환(빨강->회색)