### PR TITLE
🐛 포인트샵 오류 해결

### DIFF
--- a/dv/lib/firebase_login/signup_login.dart
+++ b/dv/lib/firebase_login/signup_login.dart
@@ -29,7 +29,7 @@ class AuthService with ChangeNotifier {
         "following": [],
         "profile": ["assets/profile/default.png"],
         "trophy": ["assets/trophy/sprout.png"],
-        "purchasedItem": ["assets/profile/default.png"],
+        "purchasedItems": [],
         "profileIdx": 0,
         "trophyIdx": 0,
         "category": 0,


### PR DESCRIPTION
purchasedItems로 설정되고, 비어있어야 할 필드가 purchasedItem으로 설정되고 프로필 디폴트 사진이 들어가 있어서 발생한  오류 << 혹시 필요한 다른 필드인지 확인 필요